### PR TITLE
feat: import and export

### DIFF
--- a/server/server/src/main/java/se/experis/tidsbanken/server/controllers/ImportExportController.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/controllers/ImportExportController.java
@@ -1,0 +1,44 @@
+package se.experis.tidsbanken.server.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import se.experis.tidsbanken.server.models.*;
+import se.experis.tidsbanken.server.services.AuthorizationService;
+import se.experis.tidsbanken.server.services.ImportExportService;
+import se.experis.tidsbanken.server.socket.NotificationObserver;
+import se.experis.tidsbanken.server.utils.ResponseUtility;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@Controller
+@CrossOrigin(origins = "*", allowedHeaders = "*")
+public class ImportExportController {
+
+    @Autowired private AuthorizationService authService;
+    @Autowired private ResponseUtility responseUtility;
+    @Autowired private NotificationObserver observer;
+    @Autowired private ImportExportService importExportService;
+
+    @GetMapping("/export")
+    public ResponseEntity<CommonResponse> exportVacations(HttpServletRequest request) {
+        if (!authService.isAuthorizedAdmin(request)) return responseUtility.unauthorized();
+        try{
+            return responseUtility
+                    .ok("All Export Data", importExportService.getExportData());
+        } catch(Exception e) { return responseUtility.errorMessage(); }
+    }
+
+    @PostMapping("/import")
+    public ResponseEntity<CommonResponse> importVacations(HttpServletRequest request,
+                                                          List<ImportExportDTO> importData){
+        if (!authService.isAuthorizedAdmin(request)) return responseUtility.unauthorized();
+        try{
+            importExportService.saveImportData(importData);
+            return responseUtility.created("All Data Was Imported!", null);
+        } catch(Exception e) { return responseUtility.errorMessage(); }
+    }
+
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/controllers/ImportExportController.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/controllers/ImportExportController.java
@@ -33,12 +33,15 @@ public class ImportExportController {
 
     @PostMapping("/import")
     public ResponseEntity<CommonResponse> importVacations(HttpServletRequest request,
-                                                          List<ImportExportDTO> importData){
+                                                          @RequestBody List<ImportExportDTO> importData){
         if (!authService.isAuthorizedAdmin(request)) return responseUtility.unauthorized();
         try{
             importExportService.saveImportData(importData);
             return responseUtility.created("All Data Was Imported!", null);
-        } catch(Exception e) { return responseUtility.errorMessage(); }
+        } catch(Exception e) {
+            /* TODO: Add different error messages depending on what went wrong */
+            return responseUtility.errorMessage();
+        }
     }
 
 }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/models/Comment.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/models/Comment.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.lang.NonNull;
 
 import javax.persistence.*;
-import java.util.Date;
+import java.sql.Date;
 import java.util.HashMap;
 
 @Entity
@@ -26,10 +26,10 @@ public class Comment {
     private User user;
 
     @Column(nullable = false)
-    private Date createdAt = new java.sql.Timestamp(new Date().getTime());
+    private Date createdAt = new java.sql.Date(System.currentTimeMillis());
 
     @Column(nullable = false)
-    private Date modifiedAt = new java.sql.Timestamp(new Date().getTime());
+    private Date modifiedAt = new java.sql.Date(System.currentTimeMillis());
 
     public Comment() { }
 
@@ -86,6 +86,6 @@ public class Comment {
     }
 
     public void updateModifiedAt() {
-        this.modifiedAt = new java.sql.Timestamp(new Date().getTime());
+        this.modifiedAt = new java.sql.Date(System.currentTimeMillis());
     }
 }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/models/Comment.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/models/Comment.java
@@ -33,6 +33,8 @@ public class Comment {
 
     public Comment() { }
 
+
+
     public Long getId() {
         return id;
     }
@@ -87,5 +89,13 @@ public class Comment {
 
     public void updateModifiedAt() {
         this.modifiedAt = new java.sql.Date(System.currentTimeMillis());
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public void setModifiedAt(Date modifiedAt) {
+        this.modifiedAt = modifiedAt;
     }
 }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/models/CommentDTO.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/models/CommentDTO.java
@@ -1,11 +1,14 @@
 package se.experis.tidsbanken.server.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.lang.NonNull;
 
 import java.sql.Date;
 
 public class CommentDTO {
+    @NonNull
     private String message;
+    @NonNull
     private Long userId;
     private Date createdAt;
     private Date modifiedAt;

--- a/server/server/src/main/java/se/experis/tidsbanken/server/models/CommentDTO.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/models/CommentDTO.java
@@ -1,0 +1,38 @@
+package se.experis.tidsbanken.server.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.sql.Date;
+
+public class CommentDTO {
+    private String message;
+    private Long userId;
+    private Date createdAt;
+    private Date modifiedAt;
+
+    public CommentDTO(String message, Long userId, Date createdAt, Date modifiedAt) {
+        this.message = message;
+        this.userId = userId;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("user_id")
+    public Long getUserId() {
+        return userId;
+    }
+
+    @JsonProperty("created_at")
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    @JsonProperty("modified_at")
+    public Date getModifiedAt() {
+        return modifiedAt;
+    }
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/models/ImportExportDTO.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/models/ImportExportDTO.java
@@ -1,0 +1,77 @@
+package se.experis.tidsbanken.server.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.sql.Date;
+import java.util.List;
+
+public class ImportExportDTO {
+    private String title;
+    private Date start;
+    private Date end;
+    private Long userId;
+    private String status;
+    private Date createdAt;
+    private Date modifiedAt;
+    private Long moderatorId;
+    private Date moderationDate;
+    private List<CommentDTO> comments;
+
+    public ImportExportDTO(String title, Date start, Date end, Long userId, String status, Date createdAt, Date modifiedAt, Long moderatorId, Date moderationDate, List<CommentDTO> comments) {
+        this.title = title;
+        this.start = start;
+        this.end = end;
+        this.userId = userId;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.moderatorId = moderatorId;
+        this.moderationDate = moderationDate;
+        this.comments = comments;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Date getStart() {
+        return start;
+    }
+
+    public Date getEnd() {
+        return end;
+    }
+
+    @JsonProperty("user_id")
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    @JsonProperty("created_at")
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    @JsonProperty("modified_at")
+    public Date getModifiedAt() {
+        return modifiedAt;
+    }
+
+    @JsonProperty("moderator_id")
+    public Long getModeratorId() {
+        return moderatorId;
+    }
+
+    @JsonProperty("moderation_date")
+    public Date getModerationDate() {
+        return moderationDate;
+    }
+
+    public List<CommentDTO> getComments() {
+        return comments;
+    }
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/models/ImportExportDTO.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/models/ImportExportDTO.java
@@ -1,15 +1,21 @@
 package se.experis.tidsbanken.server.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.lang.NonNull;
 
 import java.sql.Date;
 import java.util.List;
 
 public class ImportExportDTO {
+    @NonNull
     private String title;
+    @NonNull
     private Date start;
+    @NonNull
     private Date end;
+    @NonNull
     private Long userId;
+    @NonNull
     private String status;
     private Date createdAt;
     private Date modifiedAt;

--- a/server/server/src/main/java/se/experis/tidsbanken/server/repositories/CommentRepository.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/repositories/CommentRepository.java
@@ -13,5 +13,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByRequestOrderByCreatedAtDesc(VacationRequest request);
 
+    List<Comment> findAllByRequest(VacationRequest request);
+
     Optional<Comment> findByIdAndRequestOrderByCreatedAtDesc(Long commentId, VacationRequest request);
 }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/repositories/StatusRepository.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/repositories/StatusRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import se.experis.tidsbanken.server.models.Status;
 
+import java.util.Optional;
+
 @Repository
 public interface StatusRepository extends JpaRepository<Status, Integer> {
-
+    Optional<Status> findByStatus(String status);
 }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/services/ImportExportService.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/services/ImportExportService.java
@@ -7,7 +7,9 @@ import se.experis.tidsbanken.server.models.*;
 import se.experis.tidsbanken.server.repositories.*;
 import se.experis.tidsbanken.server.socket.NotificationObserver;
 
+import java.sql.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -16,6 +18,7 @@ public class ImportExportService {
     @Autowired private CommentRepository commentRepository;
     @Autowired private IneligiblePeriodRepository ipRepository;
     @Autowired private UserRepository userRepository;
+    @Autowired private StatusRepository statusRepository;
     @Autowired private NotificationObserver observer;
 
     @Transactional
@@ -26,8 +29,49 @@ public class ImportExportService {
     }
 
     @Transactional
-    public void saveImportData(List<ImportExportDTO> importData) {
+    public void saveImportData(List<ImportExportDTO> importData) throws Exception{
+        for (ImportExportDTO ieDTO: importData) {
+            final Optional<User> owner = userRepository.findByIdAndIsActiveTrue(ieDTO.getUserId());
+            final Optional<User> moderator = userRepository.findByIdAndIsActiveTrue(ieDTO.getModeratorId());
+            final VacationRequest vr = DTOtoVacationRequest(ieDTO, owner.orElseThrow(), moderator.orElse(null));
+            if (notValidVacationRequest(vr)) throw new Exception("Overlaps other Vacation Requests or Ineligible Periods");
+            final VacationRequest savedVr = vrRepository.save(vr);
+            final List<Comment> comments = DTOtoComments(ieDTO.getComments(), savedVr);
+            comments.forEach(c -> commentRepository.save(c.setRequest(savedVr)));
+        }
+    }
 
+    private boolean notValidVacationRequest(VacationRequest vr) {
+    return !vrRepository.findAllByOwner(vr.getOriginalOwner()).stream().allMatch(vr::excludesInPeriod)
+                || !ipRepository.findAllByOrderByStartDesc().stream().allMatch(vr::excludesInIP);
+    }
+
+    private VacationRequest DTOtoVacationRequest(ImportExportDTO dto, User owner, User moderator) {
+        final VacationRequest vr = new VacationRequest();
+        vr.setTitle(dto.getTitle());
+        vr.setStart(dto.getStart());
+        vr.setEnd(dto.getEnd());
+        vr.setOwner(owner);
+        vr.setModerator(moderator);
+        vr.setModerationDate(dto.getModerationDate());
+        Optional.of(dto.getCreatedAt()).ifPresent(vr::setCreatedAt);
+        Optional.of(dto.getModifiedAt()).ifPresent(vr::setModifiedAt);
+        vr.setStatus(statusRepository.findByStatus(dto.getStatus()).orElseThrow());
+        return vr;
+    }
+
+    private List<Comment> DTOtoComments(List<CommentDTO> commentDTOs, VacationRequest vr) {
+        return commentDTOs.stream()
+                .map(cDTO -> {
+                    final Comment c = new Comment();
+                    c.setMessage(cDTO.getMessage());
+                    c.setUser(userRepository.findByIdAndIsActiveTrue(
+                            cDTO.getUserId()).orElseThrow());
+                    Optional.of(cDTO.getCreatedAt()).ifPresent(c::setCreatedAt);
+                    Optional.of(cDTO.getModifiedAt()).ifPresent(c::setModifiedAt);
+                    c.setRequest(vr);
+                    return c;
+                }).collect(Collectors.toList());
     }
 
     private ImportExportDTO toImportExportDTO(VacationRequest vr) {

--- a/server/server/src/main/java/se/experis/tidsbanken/server/services/ImportExportService.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/services/ImportExportService.java
@@ -1,0 +1,59 @@
+package se.experis.tidsbanken.server.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se.experis.tidsbanken.server.models.*;
+import se.experis.tidsbanken.server.repositories.*;
+import se.experis.tidsbanken.server.socket.NotificationObserver;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ImportExportService {
+    @Autowired private VacationRequestRepository vrRepository;
+    @Autowired private CommentRepository commentRepository;
+    @Autowired private IneligiblePeriodRepository ipRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private NotificationObserver observer;
+
+    @Transactional
+    public List<ImportExportDTO> getExportData() {
+        return vrRepository.findAll().stream()
+                .map(this::toImportExportDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void saveImportData(List<ImportExportDTO> importData) {
+
+    }
+
+    private ImportExportDTO toImportExportDTO(VacationRequest vr) {
+        final List<Comment> comments = commentRepository.findAllByRequest(vr);
+        return new ImportExportDTO(
+                vr.getTitle(),
+                vr.getStart(),
+                vr.getEnd(),
+                vr.getOriginalOwner().getId(),
+                vr.getStatus().getStatus(),
+                vr.getCreatedAt(),
+                vr.getModifiedAt(),
+                vr.getOriginalModerator() != null
+                        ? vr.getOriginalModerator().getId()
+                        : null,
+                vr.getModerationDate(),
+                toCommentDTO(comments));
+    }
+
+    private List<CommentDTO> toCommentDTO(List<Comment> comments) {
+        return comments.stream()
+                .map(c -> new CommentDTO(
+                        c.getMessage(),
+                        c.getOriginalUser().getId(),
+                        c.getCreatedAt(),
+                        c.getModifiedAt()))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
It is now possible to import and export JSON data for Vacation Requests combined with Comments.
The object looks something like this:

```json
[
    {
        "title": "string",
        "start": "date",
        "end": "date",
        "status": "status",
        "comments": [
            {
                "message": "string",
                "user_id": "number",
                "created_at": "date",
                "modified_at": "date"
            }
        ],
        "user_id": "number",
        "created_at": "date",
        "modified_at": "date",
        "moderator_id":  "number | null",
        "moderation_date": "date | null"
    }
]
```