### PR TITLE
feat: rate-limiting

### DIFF
--- a/server/server/src/main/java/se/experis/tidsbanken/server/DTOs/CommentDTO.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/DTOs/CommentDTO.java
@@ -1,4 +1,4 @@
-package se.experis.tidsbanken.server.models;
+package se.experis.tidsbanken.server.DTOs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.lang.NonNull;

--- a/server/server/src/main/java/se/experis/tidsbanken/server/DTOs/ImportExportDTO.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/DTOs/ImportExportDTO.java
@@ -1,7 +1,8 @@
-package se.experis.tidsbanken.server.models;
+package se.experis.tidsbanken.server.DTOs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.lang.NonNull;
+import se.experis.tidsbanken.server.DTOs.CommentDTO;
 
 import java.sql.Date;
 import java.util.List;

--- a/server/server/src/main/java/se/experis/tidsbanken/server/DTOs/LoginDTO.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/DTOs/LoginDTO.java
@@ -1,4 +1,6 @@
-package se.experis.tidsbanken.server.models;
+package se.experis.tidsbanken.server.DTOs;
+
+import se.experis.tidsbanken.server.models.User;
 
 import java.util.HashMap;
 

--- a/server/server/src/main/java/se/experis/tidsbanken/server/DTOs/TwoAuthDTO.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/DTOs/TwoAuthDTO.java
@@ -1,4 +1,4 @@
-package se.experis.tidsbanken.server.models;
+package se.experis.tidsbanken.server.DTOs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/server/server/src/main/java/se/experis/tidsbanken/server/ServerApplication.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/ServerApplication.java
@@ -6,11 +6,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
-
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-
 @SpringBootApplication
 public class ServerApplication {
 
@@ -30,13 +25,4 @@ public class ServerApplication {
 		SpringApplication.run(ServerApplication.class, args);
 	}
 
-	@Bean
-	public WebMvcConfigurer corsConfigurer() {
-		return new WebMvcConfigurer() {
-			@Override
-			public void addCorsMappings(CorsRegistry registry) {
-				registry.addMapping("*").allowedOrigins("http://localhost:8080");
-			}
-		};
-	}
 }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/configurations/CorsConfig.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/configurations/CorsConfig.java
@@ -1,0 +1,37 @@
+package se.experis.tidsbanken.server.configurations;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+
+@CrossOrigin
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public FilterRegistrationBean corsFilter() {
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("OPTIONS");
+        config.addAllowedMethod("GET");
+        config.addAllowedMethod("PUT");
+        config.addAllowedMethod("POST");
+        config.addAllowedMethod("DELETE");
+        config.addAllowedMethod("PATCH");
+
+        source.registerCorsConfiguration("/**", config);
+        final FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+        bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return bean;
+    }
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/configurations/FilterConfig.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/configurations/FilterConfig.java
@@ -1,0 +1,37 @@
+package se.experis.tidsbanken.server.configurations;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import se.experis.tidsbanken.server.filters.AuthenticationFilter;
+import se.experis.tidsbanken.server.filters.RequestAttemptFilter;
+import se.experis.tidsbanken.server.services.AuthorizationService;
+import se.experis.tidsbanken.server.services.LoginAttemptService;
+
+@Configuration
+public class FilterConfig {
+
+    @Autowired private AuthorizationService authorizationService;
+    @Autowired private LoginAttemptService loginAttemptService;
+
+    @Bean
+    public FilterRegistrationBean<AuthenticationFilter> authenticationFilter(){
+        FilterRegistrationBean<AuthenticationFilter> registrationBean
+                = new FilterRegistrationBean<>();
+
+        registrationBean.setFilter(new AuthenticationFilter(authorizationService));
+        registrationBean.addUrlPatterns("/user/*", "/request/*", "/setting/*", "/import", "/export", "/ineligible/*", "/status/*");
+        registrationBean.setOrder(1);
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<RequestAttemptFilter> requestAttemptFilter() {
+        FilterRegistrationBean<RequestAttemptFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new RequestAttemptFilter(loginAttemptService));
+        registrationBean.addUrlPatterns("*");
+        registrationBean.setOrder(0);
+        return registrationBean;
+    }
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/controllers/CommentController.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/controllers/CommentController.java
@@ -7,8 +7,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import se.experis.tidsbanken.server.models.*;
-import se.experis.tidsbanken.server.repositories.CommentRepository;
-import se.experis.tidsbanken.server.repositories.VacationRequestRepository;
+import se.experis.tidsbanken.server.repositories.*;
 import se.experis.tidsbanken.server.services.AuthorizationService;
 import se.experis.tidsbanken.server.socket.NotificationObserver;
 import se.experis.tidsbanken.server.utils.ResponseUtility;
@@ -19,7 +18,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Controller
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 public class CommentController{
 
     @Autowired private CommentRepository commentRepository;
@@ -35,7 +33,6 @@ public class CommentController{
     @GetMapping("/request/{request_id}/comment")
     public ResponseEntity<CommonResponse> getComments(@PathVariable("request_id") Long requestId,
                                                       HttpServletRequest request){
-        if(!authService.isAuthorized(request)) { return responseUtility.unauthorized(); }
         try{
             final Optional<VacationRequest> vacationRequestOp = requestRepository.findById(requestId);
             if (vacationRequestOp.isPresent()) {
@@ -52,7 +49,6 @@ public class CommentController{
     public ResponseEntity<CommonResponse> createComment(@PathVariable("request_id") Long requestId,
                                                         @RequestBody Comment comment,
                                                         HttpServletRequest request) {
-        if(!authService.isAuthorized(request)) { responseUtility.unauthorized(); }
         try{
             final Optional<VacationRequest> vacationRequestOp = requestRepository.findById(requestId);
             if (vacationRequestOp.isPresent()) {
@@ -73,7 +69,6 @@ public class CommentController{
     public ResponseEntity<CommonResponse> getComment(@PathVariable("request_id") Long requestId,
                                                      @PathVariable("comment_id") Long commentId,
                                                      HttpServletRequest request){
-        if(!authService.isAuthorized(request)) { return responseUtility.unauthorized(); }
         final Optional<VacationRequest> vrOp = requestRepository.findById(requestId);
         if (vrOp.isPresent()) {
             if (!authService.isAuthorizedAdmin(request) && !isRequestOwner(vrOp.get(), request))
@@ -92,7 +87,6 @@ public class CommentController{
                                                         @PathVariable("comment_id") Long commentId,
                                                         @RequestBody Comment comment,
                                                         HttpServletRequest request) {
-        if(!authService.isAuthorized(request)) { return responseUtility.unauthorized(); }
         final Optional<VacationRequest> vrOp = requestRepository.findById(requestId);
         if(vrOp.isPresent()) {
             try {
@@ -115,7 +109,6 @@ public class CommentController{
     public ResponseEntity<CommonResponse> deleteComment(@PathVariable("request_id") Long requestId,
                                                         @PathVariable("comment_id") Long commentId,
                                                         HttpServletRequest request){
-        if(!authService.isAuthorized(request)) { return responseUtility.unauthorized(); }
         final Optional<VacationRequest> vrOp = requestRepository.findById(requestId);
         if (vrOp.isPresent()) {
             final Optional<Comment> commentOp = commentRepository.findByIdAndRequestOrderByCreatedAtDesc(commentId, vrOp.get());

--- a/server/server/src/main/java/se/experis/tidsbanken/server/controllers/ImportExportController.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/controllers/ImportExportController.java
@@ -4,9 +4,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import se.experis.tidsbanken.server.DTOs.ImportExportDTO;
 import se.experis.tidsbanken.server.models.*;
-import se.experis.tidsbanken.server.services.AuthorizationService;
-import se.experis.tidsbanken.server.services.ImportExportService;
+import se.experis.tidsbanken.server.services.*;
 import se.experis.tidsbanken.server.socket.NotificationObserver;
 import se.experis.tidsbanken.server.utils.ResponseUtility;
 
@@ -14,7 +14,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @Controller
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 public class ImportExportController {
 
     @Autowired private AuthorizationService authService;

--- a/server/server/src/main/java/se/experis/tidsbanken/server/controllers/IneligibleController.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/controllers/IneligibleController.java
@@ -17,7 +17,6 @@ import se.experis.tidsbanken.server.utils.ResponseUtility;
 
 
 @Controller
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 public class IneligibleController{
     @Autowired private IneligiblePeriodRepository ipRepository;
 
@@ -31,7 +30,6 @@ public class IneligibleController{
 
     @GetMapping("/ineligible")
     public ResponseEntity<CommonResponse> getIneligiblePeriod(HttpServletRequest request){
-        if (!authService.isAuthorized(request)) { return responseUtility.unauthorized(); }
         try { return responseUtility.ok("All ineligible periods",
                     ipRepository.findAllByOrderByStartDesc());
         } catch (Exception e) { return responseUtility.errorMessage(); }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/controllers/SettingsController.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/controllers/SettingsController.java
@@ -8,18 +8,15 @@ import org.springframework.web.bind.annotation.*;
 import se.experis.tidsbanken.server.models.CommonResponse;
 import se.experis.tidsbanken.server.models.Setting;
 import se.experis.tidsbanken.server.models.User;
-import se.experis.tidsbanken.server.repositories.SettingRepository;
-import se.experis.tidsbanken.server.repositories.UserRepository;
+import se.experis.tidsbanken.server.repositories.*;
 import se.experis.tidsbanken.server.services.AuthorizationService;
 import se.experis.tidsbanken.server.socket.NotificationObserver;
 import se.experis.tidsbanken.server.utils.ResponseUtility;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.List;
 import java.util.Optional;
 
 @Controller
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 public class SettingsController {
 
     @Autowired private ResponseUtility responseUtility;

--- a/server/server/src/main/java/se/experis/tidsbanken/server/controllers/StatusController.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/controllers/StatusController.java
@@ -2,12 +2,8 @@ package se.experis.tidsbanken.server.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
-import se.experis.tidsbanken.server.models.CommonResponse;
-import se.experis.tidsbanken.server.models.Status;
+import org.springframework.web.bind.annotation.*;
+import se.experis.tidsbanken.server.models.*;
 import se.experis.tidsbanken.server.repositories.StatusRepository;
 import se.experis.tidsbanken.server.services.AuthorizationService;
 import se.experis.tidsbanken.server.utils.ResponseUtility;
@@ -16,7 +12,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 public class StatusController {
 
     @Autowired StatusRepository statusRepository;
@@ -27,7 +22,6 @@ public class StatusController {
 
     @GetMapping("/status")
     public ResponseEntity<CommonResponse> getStatus(HttpServletRequest request) {
-        if (!authService.isAuthorized(request)) return responseUtility.unauthorized();
         try{
             return responseUtility.ok("All statuses", statusRepository.findAll());
         } catch(Exception e) { return responseUtility.errorMessage(); }
@@ -36,7 +30,6 @@ public class StatusController {
     @GetMapping("/status/{status_id}")
     public ResponseEntity<CommonResponse> getStatus(@PathVariable("status_id") Integer statusId,
                                                     HttpServletRequest request) {
-        if (!authService.isAuthorized(request)) return responseUtility.unauthorized();
         try {
             final Optional<Status> statusOp = statusRepository.findById(statusId);
             if(statusOp.isPresent())

--- a/server/server/src/main/java/se/experis/tidsbanken/server/controllers/UserController.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/controllers/UserController.java
@@ -7,8 +7,7 @@ import se.experis.tidsbanken.server.models.*;
 import se.experis.tidsbanken.server.repositories.*;
 import se.experis.tidsbanken.server.services.AuthorizationService;
 import se.experis.tidsbanken.server.socket.NotificationObserver;
-import se.experis.tidsbanken.server.utils.ResponseUtility;
-import se.experis.tidsbanken.server.utils.TwoFactorAuth;
+import se.experis.tidsbanken.server.utils.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
@@ -17,24 +16,17 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/")
-@CrossOrigin(origins = "*", allowedHeaders = "*") 
 public class UserController {
 
     @Autowired private UserRepository userRepository;
-
     @Autowired private VacationRequestRepository vacationRequestRepository;
-
     @Autowired private AuthorizationService authService;
-
     @Autowired private TwoFactorAuth twoFactorAuth;
-
     @Autowired private ResponseUtility responseUtility;
-
     @Autowired private NotificationObserver observer;
 
     @GetMapping("/user")
     public ResponseEntity<CommonResponse> getUser(HttpServletRequest request) {
-        if(!authService.isAuthorized(request)) { return responseUtility.unauthorized(); }
         final HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create("/user/" + authService.currentUser(request).getId()));
         return new ResponseEntity<>(headers, HttpStatus.SEE_OTHER);
@@ -58,7 +50,6 @@ public class UserController {
     @GetMapping("/user/{user_id}")
     public ResponseEntity<CommonResponse> getUser(@PathVariable("user_id") Long userId,
                                                   HttpServletRequest request){
-        if (!authService.isAuthorized(request)) { return responseUtility.unauthorized(); }
         final Optional<User> fetchedUser = userRepository.findByIdAndIsActiveTrue(userId);
         if (fetchedUser.isPresent()){
             return responseUtility
@@ -124,7 +115,6 @@ public class UserController {
     @GetMapping("/user/{user_id}/requests")
     public ResponseEntity<CommonResponse> getUserVacationRequests(@PathVariable("user_id") Long userId,
                                                                   HttpServletRequest request){
-        if(!authService.isAuthorized(request)) { return responseUtility.unauthorized(); }
         final Optional<User> fetchedUser = userRepository.findByIdAndIsActiveTrue(userId);
         if (fetchedUser.isPresent()){
             Object data;

--- a/server/server/src/main/java/se/experis/tidsbanken/server/filters/AuthenticationFilter.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/filters/AuthenticationFilter.java
@@ -1,0 +1,40 @@
+package se.experis.tidsbanken.server.filters;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import se.experis.tidsbanken.server.services.AuthorizationService;
+import se.experis.tidsbanken.server.services.LoginAttemptService;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AuthenticationFilter implements Filter {
+
+    final private AuthorizationService authorizationService;
+
+    @Autowired
+    public AuthenticationFilter(AuthorizationService authorizationService) {
+        this.authorizationService = authorizationService;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        final HttpServletRequest req = (HttpServletRequest) servletRequest;
+        if (!authorizationService.isAuthorized(req)) {
+            ((HttpServletResponse) servletResponse).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/filters/RequestAttemptFilter.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/filters/RequestAttemptFilter.java
@@ -1,0 +1,38 @@
+package se.experis.tidsbanken.server.filters;
+
+import org.springframework.http.HttpStatus;
+import se.experis.tidsbanken.server.services.LoginAttemptService;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class RequestAttemptFilter implements Filter {
+
+    private final LoginAttemptService loginAttemptService;
+
+    public RequestAttemptFilter(LoginAttemptService loginAttemptService) {
+        this.loginAttemptService = loginAttemptService;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        final HttpServletRequest req = (HttpServletRequest) servletRequest;
+        if (!loginAttemptService.checkFailedLoginAttempt(req)) {
+            ((HttpServletResponse) servletResponse).sendError(HttpStatus.TOO_MANY_REQUESTS.value());
+            return;
+        }
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/models/LoginAttempt.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/models/LoginAttempt.java
@@ -1,0 +1,47 @@
+package se.experis.tidsbanken.server.models;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.sql.Date;
+import java.sql.Timestamp;
+
+@Entity
+public class LoginAttempt {
+    @Id
+    private String ip;
+
+    @Column(columnDefinition = "Integer default 1")
+    private Integer failedAttempts = 1;
+
+    @Column
+    private Timestamp blockedTimeStamp;
+
+    public LoginAttempt() {}
+
+    public LoginAttempt(String ip) {
+        this.ip = ip;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public Integer getFailedAttempts() {
+        return failedAttempts;
+    }
+
+    public Timestamp getBlockedTimeStamp() {
+        return blockedTimeStamp;
+    }
+
+    public LoginAttempt incrementFailedAttempts() {
+        this.failedAttempts++;
+        return this;
+    }
+
+    public LoginAttempt setToBlocked() {
+        this.blockedTimeStamp = new java.sql.Timestamp(System.currentTimeMillis() + 1000 * 60 * 10);
+        return this;
+    }
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/repositories/LoginAttemptRepository.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/repositories/LoginAttemptRepository.java
@@ -1,0 +1,12 @@
+package se.experis.tidsbanken.server.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import se.experis.tidsbanken.server.models.LoginAttempt;
+
+import java.util.Optional;
+
+@Repository
+public interface LoginAttemptRepository extends JpaRepository<LoginAttempt, String> {
+    Optional<LoginAttempt> findByIp(String ip);
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/services/AuthorizationService.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/services/AuthorizationService.java
@@ -25,7 +25,6 @@ public class AuthorizationService {
     public Boolean isAuthorizedUser(HttpServletRequest request) {
         try { return isAuthorizedRole(request, UserRole.USER);
         } catch (Exception e) {
-            e.printStackTrace();
             return false;
         }
     }
@@ -35,7 +34,6 @@ public class AuthorizationService {
             final String jwt = extractToken(request);
             return isAuthorized(jwt);
         } catch (Exception e) {
-            e.printStackTrace();
             return false;
         }
     }
@@ -46,7 +44,6 @@ public class AuthorizationService {
             final User user = userRepository.findByIdAndIsActiveTrue(userId).get();
             return jwtUtil.validateToken(jwt, user);
         } catch (Exception e) {
-            e.printStackTrace();
             return false;
         }
     }
@@ -58,7 +55,6 @@ public class AuthorizationService {
             final User user = userRepository.findByIdAndIsActiveTrue(userId).get();
             return jwtUtil.validateToken(jwt, user, userRole.toString());
         }catch (Exception e) {
-            e.printStackTrace();
             return false;
         }
     }
@@ -75,7 +71,6 @@ public class AuthorizationService {
             final String jwt = extractToken(request);
             return currentUser(jwt);
         } catch (Exception e) {
-            e.printStackTrace();
             return null;
         }
     }
@@ -85,7 +80,6 @@ public class AuthorizationService {
             final Long userId = jwtUtil.extractUserId(jwt);
             return userRepository.findByIdAndIsActiveTrue(userId).get();
         } catch (Exception e) {
-            e.printStackTrace();
             return null;
         }
     }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/services/ImportExportService.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/services/ImportExportService.java
@@ -3,11 +3,12 @@ package se.experis.tidsbanken.server.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import se.experis.tidsbanken.server.DTOs.CommentDTO;
+import se.experis.tidsbanken.server.DTOs.ImportExportDTO;
 import se.experis.tidsbanken.server.models.*;
 import se.experis.tidsbanken.server.repositories.*;
 import se.experis.tidsbanken.server.socket.NotificationObserver;
 
-import java.sql.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/server/server/src/main/java/se/experis/tidsbanken/server/services/LoginAttemptService.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/services/LoginAttemptService.java
@@ -1,0 +1,55 @@
+package se.experis.tidsbanken.server.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import se.experis.tidsbanken.server.models.LoginAttempt;
+import se.experis.tidsbanken.server.repositories.LoginAttemptRepository;
+
+import javax.servlet.http.HttpServletRequest;
+import java.sql.Timestamp;
+import java.util.Optional;
+
+@Service
+public class LoginAttemptService {
+
+    @Autowired private LoginAttemptRepository loginAttemptRepository;
+
+    public boolean checkFailedLoginAttempt(HttpServletRequest request) {
+        final Optional<LoginAttempt> loginAttemptOp = loginAttemptRepository.findByIp(request.getRemoteAddr());
+        if (loginAttemptOp.isPresent()) {
+            final LoginAttempt loginAttempt = loginAttemptOp.get();
+            if (checkMaxAttempts(loginAttempt)) {
+                if (loginAttempt.getBlockedTimeStamp() == null) return false;
+                if (checkIsBlocked(loginAttempt)) {
+                    loginAttemptRepository.save(loginAttempt.setToBlocked());
+                    return false;
+                } else {
+                    loginAttemptRepository.delete(loginAttempt);
+                }
+            }
+        }
+        return true;
+    }
+
+    public void addFailedLoginAttempt(HttpServletRequest request) {
+        final Optional<LoginAttempt> loginAttemptOp = loginAttemptRepository.findByIp(request.getRemoteAddr());
+        if (loginAttemptOp.isPresent()) {
+            final LoginAttempt loginAttempt = loginAttemptOp.get().incrementFailedAttempts();
+            if (checkMaxAttempts(loginAttempt)) {
+                loginAttemptRepository.save(loginAttempt.setToBlocked());
+            } else {
+                loginAttemptRepository.save(loginAttemptOp.get().incrementFailedAttempts());
+            }
+        } else {
+            loginAttemptRepository.save(new LoginAttempt(request.getRemoteAddr()));
+        }
+    }
+
+    private boolean checkIsBlocked(LoginAttempt loginAttempt) {
+        return loginAttempt.getBlockedTimeStamp() != null && loginAttempt.getBlockedTimeStamp().after(new Timestamp(System.currentTimeMillis()));
+    }
+
+    private boolean checkMaxAttempts(LoginAttempt loginAttempt) {
+        return loginAttempt.getFailedAttempts() >= 10;
+    }
+}

--- a/server/server/src/main/java/se/experis/tidsbanken/server/utils/ResponseUtility.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/utils/ResponseUtility.java
@@ -37,6 +37,10 @@ public class ResponseUtility {
         return ResponseEntity.status(HttpStatus.CREATED).body(new CommonResponse().message(message).data(data));
     }
 
+    public ResponseEntity<CommonResponse> tooManyRequests() {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(new CommonResponse().message("Too Many Failed Attempts"));
+    }
+
     private ResponseEntity<CommonResponse> buildResponse(HttpStatus status, String message) {
         return ResponseEntity.status(status).body(new CommonResponse().message(message));
     }

--- a/server/server/src/main/java/se/experis/tidsbanken/server/utils/TwoFactorAuth.java
+++ b/server/server/src/main/java/se/experis/tidsbanken/server/utils/TwoFactorAuth.java
@@ -6,7 +6,7 @@ import dev.samstevens.totp.qr.ZxingPngQrGenerator;
 import dev.samstevens.totp.time.SystemTimeProvider;
 import dev.samstevens.totp.time.TimeProvider;
 import org.springframework.stereotype.Component;
-import se.experis.tidsbanken.server.models.TwoAuthDTO;
+import se.experis.tidsbanken.server.DTOs.TwoAuthDTO;
 
 @Component
 public class TwoFactorAuth {


### PR DESCRIPTION
This rate-limiting feature checks if the request performer is registered in the database. If they are we check if they have a banned timestamp. If they have a timestamp they will only get TOO_MANY_REQUESTS responses till after the timestamp.

Did also refactor the cors and authentication to use "filters" instead. Basically, we go through a filter before reaching the wished endpoint. Every endpoint will check if the request performers' IP is banned, and all endpoints except login will check if the user has an authentication JWT.